### PR TITLE
Double clicking

### DIFF
--- a/jQuery.fastClick.js
+++ b/jQuery.fastClick.js
@@ -51,7 +51,7 @@ $.FastButton = function(element, handler) {
 	var onTouchStart = function(event) {
 		event.stopPropagation();
 	
-		$(element).bind('touchend', onClick);
+		$(element).bind('touchend', onTouchStart);
 		$(document.body).bind('touchmove', onTouchMove);
 	
 		startX = event.touches[0].clientX;


### PR DESCRIPTION
It was binding onClick to touchend in onTouchStart(), causing duplicate handling of clicks. This should fix it.
