### PR TITLE
Fixed jQuery selector

### DIFF
--- a/jQuery.fastClick.js
+++ b/jQuery.fastClick.js
@@ -28,7 +28,7 @@ $.FastButton = function(element, handler) {
 
 	var reset = function() {
 		$(element).unbind('touchend');
-		$(document.fastButton).unbind('touchmove');
+		$("body").unbind('touchmove.fastClick');
 	};
 
 	var onClick = function(event) {
@@ -52,7 +52,7 @@ $.FastButton = function(element, handler) {
 		event.stopPropagation();
 
 		$(element).bind('touchend', onClick);
-		$(document.fastButton).bind('touchmove', onTouchMove);
+		$("body").bind('touchmove.fastClick', onTouchMove);
 
 		startX = event.originalEvent.touches[0].clientX;
 		startY = event.originalEvent.touches[0].clientY;


### PR DESCRIPTION
I used a incorrect jQuery selector last time which meant that touchmove events weren't caught and incorrectly triggered a click. This pull request fixes that.
