### PR TITLE
uses existing onclick handlers, if available

### DIFF
--- a/jQuery.fastClick.js
+++ b/jQuery.fastClick.js
@@ -72,6 +72,7 @@ $.FastButton = function(element, handler) {
 
 	$(element).bind({
 		touchstart: onTouchStart,
+		mouseover: function() { return false; },
 		click: onClick
 	});
 };

--- a/jQuery.fastClick.js
+++ b/jQuery.fastClick.js
@@ -19,7 +19,19 @@
 
 $.fn.fastClick = function(handler) {
 	return $(this).each(function(){
-		$.FastButton($(this)[0], handler);
+		var button = $(this)[0],
+				clickEvent = null;
+
+		if (handler == null) {
+			if (button.onclick instanceof Function) {
+				clickEvent = button.onclick;
+				button.onclick = '';
+			}
+		}
+
+		if (handler != null || clickEvent != null) {
+			$.FastButton(button, handler || clickEvent);
+		}
 	});
 };
 

--- a/jQuery.fastClick.js
+++ b/jQuery.fastClick.js
@@ -70,7 +70,7 @@ $.FastButton = function(element, handler) {
 		startY = event.originalEvent.touches[0].clientY;
 	};
 
-	$(element).unbind("click");
+	$(element).unbind();
 	$(element).bind({
 		touchstart: onTouchStart,
 		mouseover: function() { return false; },

--- a/jQuery.fastClick.js
+++ b/jQuery.fastClick.js
@@ -70,6 +70,7 @@ $.FastButton = function(element, handler) {
 		startY = event.originalEvent.touches[0].clientY;
 	};
 
+	$(element).unbind("click");
 	$(element).bind({
 		touchstart: onTouchStart,
 		mouseover: function() { return false; },


### PR DESCRIPTION
hi there

this is just a small change to get the existing onclick handlers handled by fastclick automatically, as somebody requested in issue #13. it still degrades to "normal/manual" mode gracefully.

thanks

btw. this is my first pull-request ever... please support me with some feedback if i'm doing anything the wrong way :)
